### PR TITLE
Integration to Main (0.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 musicscan CHANGELOG
 ======================
 
-## CURRENT
+## RELEASE 0.1.7
+ - [musicscan-57](https://github.com/cjcodeproj/musicscan/issues/57) Release 0.1.7
  - [musicscan-36](https://github.com/cjcodeproj/musicscan/issues/36) Update some editing notes
  - [musicscan-52](https://github.com/cjcodeproj/musicscan/issues/52) Add new flags to RST documentation
  - [musicscan-40](https://github.com/cjcodeproj/musicscan/issues/40) Documentation: flags option flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 musicscan CHANGELOG
 ======================
 
+## CURRENT
+ - [musicscan-36](https://github.com/cjcodeproj/musicscan/issues/36) Update some editing notes
+ - [musicscan-52](https://github.com/cjcodeproj/musicscan/issues/52) Add new flags to RST documentation
+ - [musicscan-40](https://github.com/cjcodeproj/musicscan/issues/40) Documentation: flags option flag
+ - [musicscan-53](https://github.com/cjcodeproj/musicscan/issues/53) Album title is not sanitized
+ - [musicscan-51](https://github.com/cjcodeproj/musicscan/issues/51) Edit flag for Intro and Reprise
+ - [musicscan-22](https://github.com/cjcodeproj/musicscan/issues/22) Flag codes should probably be distinct between album and song
+ - [musicscan-49](https://github.com/cjcodeproj/musicscan/issues/49) id3scan should be a bin tool
+
+
 ## RELEASE 0.1.5
  - [musicscan-46](https://github.com/cjcodeproj/musicscan/issues/46) Release 0.1.5
  - [musicscan-34](https://github.com/cjcodeproj/musicscan/issues/34) Flag for bonus tracks

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ music collection and builds a set of XML files adhering to the vtmedia schema.
 It includes a tool that will recursively scan a directory for audio files
 containing ID3 tags and uses that data as the basis for bulding XML files.
 
+
+ * [How It Works](#how-it-works)
+ * [XML Schema](#xml-schema)
+ * [Scanning Example](#scanning-example)
+     * [The Audio CD File](#the-audio-cd-file)
+     * [The Index File](#the-index-file)
+     * [The Album File](#the-album-file)
+ * [Documentation](#documentation)
+ * [Building And Installing From Source Code](#building-and-installing-from-source-code)
+ * [Package Distribution](#package-distribution)
+
+
 ## How It Works
 
 It works under the assumption that the digital library was created by importing CDs
@@ -52,10 +64,11 @@ $ ls -1 "~/Music/iTunes/iTunes Media/Music/Garth Brooks/No Fences/"
 10 Wolves.m4a
 ```
 
-The `id3scan` tool will search that directory and create three files.
+The `id3scan` tool will search that directory and create three files.  Make sure the install path for the id3scan tool
+matches your environment command path.
 
 ```
-$ python3 -m musicscan.tools.id3scan --musicpath "~/Music/iTunes/iTunes Media/Music/Garth Brooks/No Fences" --write --outdir ~/tmp --split-xml
+$ id3scan --musicpath "~/Music/iTunes/iTunes Media/Music/Garth Brooks/No Fences" --write --outdir ~/tmp --split-xml
 ```
 
 ```

--- a/doc/id3scan.rst
+++ b/doc/id3scan.rst
@@ -5,14 +5,14 @@ musisscan.tools.id3scan
 NAME
 ----
 
-musicscan.tools.id3scan - scan files for ID3 metadata to build XML structures
+id3scan - scan files for ID3 metadata to build XML structures
 
 SYNOPSIS
 --------
 
 ::
 
-  python -m musicscan.tools.id3scan [-h] [--musicpath PATH]
+  id3scan [-h] [--musicpath PATH]
          [--outdir PATH]
          [--write/--no-write]
          [--split-xml/--no-split-xml]
@@ -48,7 +48,7 @@ OPTIONS
     If existing XML files are already in the output path, they will be overwritten.
 
 ``--flags``
-    If specified, additional XML comments will be embedded in the file containing
+    By default, additional XML comments will be embedded in the file containing context
     hints about the data, such as whether a song has a featured guest artist,
     or if a track is just filler material from the source CD.
 
@@ -77,8 +77,8 @@ correctly identify multiple artists, or distinguish between an individual artist
 If you don't like the results of your editing, it's possible to just delete the data
 and re-generate it by running the id3scan again.
 
-FLAGS
------
+ALBUM FLAGS
+-----------
 
 Flags are embedded information in the XML comments that provide information on
 how the software has interpreted the metadata
@@ -92,8 +92,18 @@ how the software has interpreted the metadata
 ``possible_soundtrack``
     The album is possibly a soundtrack from a film, television show, or play.
 
-``possible_score```
+``possible_score``
     The album is possible a musical score from a film, television show, or play.
+
+``possible_tribute``
+  The album is possibly a tribute to another musical artist.
+
+``possible_intro_and_reprise``
+  The first track of the album may be an introduction, and the final track may
+  be a repreise.
+
+TRACK FLAGS
+-----------
 
 ``detected_square_brackets``
     Square brackets were detected in the title of the track, suggesting extra
@@ -122,12 +132,27 @@ how the software has interpreted the metadata
 ``possible_blank_track``
     The track is possibly a blank track that contains no actual music.
 
+``possible_bonus_track``
+    It's possible the track is a bonus track, which could appear
+    on a re-issue of a CD or record.
+
 ``country_and_folk_genre_is_too_vague``
     The metadata genre value for the track is "Country & Folk", which
     actually is two different genres.  The value should be changed to
     the more accurate value.
 
+``missing_copyright_year``
+    The copyright year information could be missing.
 
+``missing_artist``
+    The artist name is missing
+
+``possible_intro_track``
+   The track could serve as an introduction to the album, or
+   to another track.
+
+``possible_reprise_track``
+    The track could serve as a reprise to the album.
 
 ENVIRONMENT VARIABLES
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "musicscan"
-version = "0.1.5"
+version = "0.1.6"
 description = "Package for converting music metadata to XML"
 readme = "README.md"
 requires-python = ">3.8"
@@ -33,6 +33,8 @@ homepage = "https://github.com/cjcodeproj/musicscan"
 repository = "https://github.com/cjcodeproj/musicscan"
 changelog = "https://github.com/cjcodeproj/musicscan/blob/main/CHANGELOG.md"
 
+[project.scripts]
+id3scan = "musicscan.tools.id3scan:main_cli"
 
 [tools.setuptools]
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "musicscan"
-version = "0.1.6"
+version = "0.1.7"
 description = "Package for converting music metadata to XML"
 readme = "README.md"
 requires-python = ">3.8"

--- a/src/musicscan/data/analyzer.py
+++ b/src/musicscan/data/analyzer.py
@@ -26,9 +26,11 @@
 Testing code to identify possible edit flags.
 '''
 
+# pylint: disable=too-many-public-methods
+
 import re
 from musicscan.data.cd import Album
-from musicscan.data.flags import FlagCodes
+from musicscan.data.flags import AlbumFlagCodes, TrackFlagCodes
 from musicscan.data.track import Track
 
 
@@ -42,11 +44,25 @@ class Analyzer():
         '''
         Main album testing routine.
         '''
+        self.album_tests(in_album)
+        self.track_tests(in_album)
+        self.album_closing_tests(in_album)
+
+    def album_tests(self, in_album: Album):
+        '''
+        Perform tests against the album.
+        '''
         self.check_album_values(in_album)
         self.test_album_title(in_album)
         self.test_album_artist(in_album)
         self.test_soundtrack(in_album)
         self.test_score(in_album)
+        self.test_tribute(in_album)
+
+    def track_tests(self, in_album: Album):
+        '''
+        Perform tests against every track.
+        '''
         for dsc in sorted(in_album.discs):
             for trk in sorted(in_album.discs[dsc].tracks,
                               key=lambda x: x.track_no):
@@ -57,6 +73,15 @@ class Analyzer():
                 self.test_track_genre(trk)
                 self.test_album_track_blank(trk)
                 self.test_album_track_bonus(trk)
+                self.test_album_track_intro(trk)
+                self.test_album_track_reprise(trk)
+
+    def album_closing_tests(self, in_album: Album):
+        '''
+        Perform additional tests after all
+        tracks are analzed.
+        '''
+        self.test_intro_reprise_presence(in_album)
 
     def check_album_values(self, in_album: Album):
         '''
@@ -65,7 +90,7 @@ class Analyzer():
         '''
         if not in_album.title:
             in_album.title = 'PLACEHOLDER ALBUM TITLE'
-            in_album.flags.add_flag(FlagCodes.m_album_title)
+            in_album.flags.add_flag(TrackFlagCodes.m_album_title)
 
     def check_track_values(self, in_track: Track):
         '''
@@ -74,7 +99,7 @@ class Analyzer():
         '''
         if not in_track.artist:
             in_track.artist = 'PLACEHOLDER TRACK ARTIST'
-            in_track.flags.add_flag(FlagCodes.m_track_artist)
+            in_track.flags.add_flag(TrackFlagCodes.m_track_artist)
 
     def test_album_title(self, in_album: Album):
         '''
@@ -84,9 +109,9 @@ class Analyzer():
         greatest_p = re.compile(r'Greatest', re.IGNORECASE)
         hits_p = re.compile(r'\s+Hit', re.IGNORECASE)
         if greatest_p.search(in_album.title):
-            in_album.flags.add_flag(FlagCodes.p_greatest)
+            in_album.flags.add_flag(AlbumFlagCodes.p_greatest)
         if hits_p.search(in_album.title):
-            in_album.flags.add_flag(FlagCodes.p_hits_compo)
+            in_album.flags.add_flag(AlbumFlagCodes.p_hits_compo)
 
     def test_soundtrack(self, in_album: Album):
         '''
@@ -96,10 +121,10 @@ class Analyzer():
         first_track = in_album.first_track()
         soundtrack_p = re.compile(r'\s+Soundtrack\s+', re.IGNORECASE)
         if soundtrack_p.search(in_album.title):
-            in_album.flags.add_flag(FlagCodes.p_soundtrack)
+            in_album.flags.add_flag(AlbumFlagCodes.p_soundtrack)
         if first_track.genre == 'Soundtrack':
-            if FlagCodes.p_soundtrack not in in_album.flags.flags:
-                in_album.flags.add_flag(FlagCodes.p_soundtrack)
+            if AlbumFlagCodes.p_soundtrack not in in_album.flags.flags:
+                in_album.flags.add_flag(AlbumFlagCodes.p_soundtrack)
 
     def test_score(self, in_album: Album):
         '''
@@ -108,7 +133,16 @@ class Analyzer():
         '''
         score_p = re.compile(r'\s+Score\s+', re.IGNORECASE)
         if score_p.search(in_album.title):
-            in_album.flags.add_flag(FlagCodes.p_score)
+            in_album.flags.add_flag(AlbumFlagCodes.p_score)
+
+    def test_tribute(self, in_album: Album):
+        '''
+        Test if the album title suggests that it is a
+        tribute to another artist.
+        '''
+        tribute_p = re.compile(r'\s+Tribute\s+', re.IGNORECASE)
+        if tribute_p.search(in_album.title):
+            in_album.flags.add_flag(AlbumFlagCodes.p_tribute)
 
     def test_album_artist(self, in_album: Album):
         '''
@@ -117,7 +151,7 @@ class Analyzer():
         '''
         and_p = re.compile(r'\s+and\s+', re.IGNORECASE)
         if and_p.search(str(in_album.artist)):
-            in_album.flags.add_flag(FlagCodes.l_group)
+            in_album.flags.add_flag(TrackFlagCodes.l_group)
 
     def test_album_track_chrs(self, in_track: Track):
         '''
@@ -125,9 +159,9 @@ class Analyzer():
         have been embeded in the track name in parenthesis.
         '''
         if '[' in in_track.title or ']' in in_track.title:
-            in_track.flags.add_flag(FlagCodes.d_sq_brackets)
+            in_track.flags.add_flag(TrackFlagCodes.d_sq_brackets)
         if '(' in in_track.title or ')' in in_track.title:
-            in_track.flags.add_flag(FlagCodes.d_parenthesis)
+            in_track.flags.add_flag(TrackFlagCodes.d_parenthesis)
 
     def test_album_track_featured(self, in_track: Track):
         '''
@@ -137,9 +171,9 @@ class Analyzer():
         feature_p = re.compile(r'Feat', re.IGNORECASE)
         with_p = re.compile(r'With\s+', re.IGNORECASE)
         if feature_p.search(in_track.title) or with_p.search(in_track.title):
-            in_track.flags.add_flag(FlagCodes.p_feat_artist)
+            in_track.flags.add_flag(TrackFlagCodes.p_feat_artist)
         if feature_p.search(in_track.artist) or with_p.search(in_track.artist):
-            in_track.flags.add_flag(FlagCodes.p_feat_artist)
+            in_track.flags.add_flag(TrackFlagCodes.p_feat_artist)
 
     def test_album_track_live(self, in_track: Track):
         '''
@@ -148,7 +182,7 @@ class Analyzer():
         '''
         live_p = re.compile(r'Live\s+', re.IGNORECASE)
         if live_p.search(in_track.title):
-            in_track.flags.add_flag(FlagCodes.p_live)
+            in_track.flags.add_flag(TrackFlagCodes.p_live)
 
     def test_track_genre(self, in_track: Track):
         '''
@@ -157,7 +191,7 @@ class Analyzer():
         country_p = re.compile(r'Country & Folk', re.IGNORECASE)
         if in_track.genre:
             if country_p.search(in_track.genre):
-                in_track.flags.add_flag(FlagCodes.p_genre_country_folk)
+                in_track.flags.add_flag(TrackFlagCodes.p_genre_country_folk)
 
     def test_album_track_demo(self, in_track: Track):
         '''
@@ -166,7 +200,7 @@ class Analyzer():
         '''
         demo_p = re.compile(r'Demo', re.IGNORECASE)
         if demo_p.search(in_track.title):
-            in_track.flags.add_flag(FlagCodes.p_demo)
+            in_track.flags.add_flag(TrackFlagCodes.p_demo)
 
     def test_album_track_blank(self, in_track: Track):
         '''
@@ -175,7 +209,7 @@ class Analyzer():
         '''
         blank_p = re.compile(r'Blank', re.IGNORECASE)
         if blank_p.search(in_track.title):
-            in_track.flags.add_flag(FlagCodes.p_blank_track)
+            in_track.flags.add_flag(TrackFlagCodes.p_blank_track)
 
     def test_album_track_bonus(self, in_track: Track):
         '''
@@ -185,4 +219,42 @@ class Analyzer():
         '''
         bonus_p = re.compile(r'\W+Bonus', re.IGNORECASE)
         if bonus_p.search(in_track.title):
-            in_track.flags.add_flag(FlagCodes.p_bonus_track)
+            in_track.flags.add_flag(TrackFlagCodes.p_bonus_track)
+
+    def test_album_track_intro(self, in_track: Track):
+        '''
+        Test the track to see if it is an introduction to
+        another track, or possibly for the album itself.
+        '''
+        intro_p = re.compile(r'[\s\W]?Intro', re.IGNORECASE)
+        if intro_p.search(in_track.title):
+            in_track.flags.add_flag(TrackFlagCodes.p_intro)
+
+    def test_album_track_reprise(self, in_track: Track):
+        '''
+        Test the track to see if it is labeled as a
+        reprise, either to the album, or to a previous
+        track on the album.
+        '''
+        reprise_p = re.compile(r'[\s\W]?Reprise', re.IGNORECASE)
+        if reprise_p.search(in_track.title):
+            in_track.flags.add_flag(TrackFlagCodes.p_reprise)
+
+    def test_intro_reprise_presence(self, in_album: Album):
+        '''
+        Test to see if both an intro and reprise is
+        contained in the album, and add an additional
+        album level flag to identify it.
+        '''
+        reprise = False
+        intro = False
+        for dsc in sorted(in_album.discs):
+            for trk in sorted(in_album.discs[dsc].tracks,
+                              key=lambda x: x.track_no):
+                if TrackFlagCodes.p_intro in trk.flags:
+                    intro = True
+                if TrackFlagCodes.p_reprise in trk.flags:
+                    reprise = True
+                if intro and reprise:
+                    in_album.flags.add_flag(AlbumFlagCodes.p_intro_reprise)
+                    break

--- a/src/musicscan/data/cd.py
+++ b/src/musicscan/data/cd.py
@@ -28,7 +28,8 @@ Data objects for music.
 
 # pylint: disable=too-many-instance-attributes
 
-from musicscan.data.flags import Flags, FlagCodes
+from musicscan.data.flags import AlbumFlags
+from musicscan.data.flagcodes import TrackFlagCodes
 from musicscan.data.titletools import ShortTitleIndex, ShortTitle
 from musicscan.data.track import Track
 from musicscan.data.stringtools import build_complete_filename
@@ -46,7 +47,7 @@ class Album():
         self.title_index = ShortTitleIndex()
         self.discs = {}
         self._first_disc = None
-        self.flags = Flags()
+        self.flags = AlbumFlags()
         self.track_count = 0
 
     def import_tag(self, in_tag):
@@ -165,7 +166,7 @@ class Disc():
         for trk in sort_t:
             if not trk.title:
                 trk.title = 'PLACEHOLDER TITLE'
-                trk.flags.add_flag(FlagCodes.m_title)
+                trk.flags.add_flag(TrackFlagCodes.m_title)
             trk.short_title = ShortTitle(trk.title, self.album.title_index)
 
     def report(self):

--- a/src/musicscan/data/flagcodes.py
+++ b/src/musicscan/data/flagcodes.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+'''
+Flags represent additional data added to XML output for the purpose
+of identifying likely data that will probably need closer scrutiny.
+
+Each album and song has a flag object, which will contain zero or
+more flags that will be output as an XML comment with the XML elements.
+'''
+
+# pylint: disable=R0903
+
+
+class AlbumFlagCodes():
+    '''
+    All flag codes related to albums.
+    '''
+    p_greatest = 1
+    p_hits_compo = 2
+    p_soundtrack = 3
+    p_score = 4
+    p_tribute = 5
+    p_intro_reprise = 10
+
+    @classmethod
+    def to_str(cls, in_code: int) -> str:
+        '''
+        Convert an album flag code to a usable string.
+        '''
+        matrix = {AlbumFlagCodes.p_greatest: 'possible_greatest_hits',
+                  AlbumFlagCodes.p_hits_compo: 'possible_hits_compilation',
+                  AlbumFlagCodes.p_soundtrack: 'possible_soundtrack',
+                  AlbumFlagCodes.p_score: 'possible_score',
+                  AlbumFlagCodes.p_tribute: 'possible_tribute',
+                  AlbumFlagCodes.p_intro_reprise: 'possible_intro_and_reprise'}
+        if in_code in matrix:
+            return matrix[in_code]
+        return ''
+
+
+class TrackFlagCodes():
+    '''
+    All flag codes related to tracks.
+    '''
+    d_sq_brackets = 110
+    d_parenthesis = 111
+    l_group = 120
+    p_feat_artist = 130
+    p_live = 131
+    p_demo = 132
+    p_blank_track = 140
+    p_bonus_track = 141
+    p_genre_country_folk = 150
+    m_year = 160
+    m_title = 161
+    m_album_title = 162
+    m_track_artist = 163
+    p_intro = 170
+    p_reprise = 171
+
+    @classmethod
+    def to_str(cls, in_code: int) -> str:
+        '''
+        Convert a flag value to a usable string.
+        '''
+        matrix = {TrackFlagCodes.d_sq_brackets: 'detected_square_brackets',
+                  TrackFlagCodes.d_parenthesis: 'detected_parenthesis',
+                  TrackFlagCodes.l_group: 'likely_group_artist',
+                  TrackFlagCodes.p_feat_artist: 'possible_featured_artist',
+                  TrackFlagCodes.p_live: 'possible_live_performance',
+                  TrackFlagCodes.p_demo: 'possible_demo_performance',
+                  TrackFlagCodes.p_blank_track: 'possible_blank_track',
+                  TrackFlagCodes.p_bonus_track: 'possible_bonus_track',
+                  TrackFlagCodes.p_genre_country_folk:
+                  'country_and_folk_genre_is_too_vague',
+                  TrackFlagCodes.m_year: 'missing_copyright_year',
+                  TrackFlagCodes.m_title: 'missing_title',
+                  TrackFlagCodes.m_album_title: 'missing_album_title',
+                  TrackFlagCodes.m_track_artist: 'missing_artist',
+                  TrackFlagCodes.p_intro: 'possible_intro_track',
+                  TrackFlagCodes.p_reprise: 'possible_reprise_track'}
+        if in_code in matrix:
+            return matrix[in_code]
+        return ''

--- a/src/musicscan/data/flags.py
+++ b/src/musicscan/data/flags.py
@@ -32,8 +32,10 @@ more flags that will be output as an XML comment with the XML elements.
 
 # pylint: disable=R0903
 
+from musicscan.data.flagcodes import AlbumFlagCodes, TrackFlagCodes
 
-class Flags():
+
+class AlbumFlags():
     '''
     Flags are warnings that are output in the XML
     so users can identify possible issues with
@@ -41,6 +43,9 @@ class Flags():
     '''
     def __init__(self):
         self.flags = []
+
+    def __contains__(self, in_flag: AlbumFlagCodes):
+        return in_flag in self.flags
 
     def add_flag(self, in_code: int):
         '''
@@ -58,56 +63,39 @@ class Flags():
         if len(self.flags) > 0:
             flag_string = ''
             for f_code in self.flags:
-                flag_string += FlagCodes.to_str(f_code) + ' '
+                flag_string += AlbumFlagCodes.to_str(f_code) + ' '
             return f"{p_str}<!-- EDIT FLAGS: {flag_string} -->\n"
         return ''
 
 
-class FlagCodes():
+class TrackFlags():
     '''
-    All possible flag values
+    Flags are warnings that are output in the XML
+    so users can identify possible issues with
+    the interpreted data.
     '''
-    p_greatest = 1
-    p_hits_compo = 2
-    p_soundtrack = 3
-    p_score = 4
-    d_sq_brackets = 10
-    d_parenthesis = 11
-    l_group = 20
-    p_feat_artist = 30
-    p_live = 31
-    p_demo = 32
-    p_blank_track = 40
-    p_bonus_track = 41
-    p_genre_country_folk = 50
-    m_year = 60
-    m_title = 61
-    m_album_title = 62
-    m_track_artist = 63
+    def __init__(self):
+        self.flags = []
 
-    @classmethod
-    def to_str(cls, in_code: int) -> str:
+    def __contains__(self, in_flag: TrackFlagCodes):
+        return in_flag in self.flags
+
+    def add_flag(self, in_code: int):
         '''
-        Convert a flag value to a usable string.
+        Add a FlagCode to the array.
         '''
-        matrix = {FlagCodes.p_greatest: 'possible_greatest_hits',
-                  FlagCodes.p_hits_compo: 'possible_hits_compilation',
-                  FlagCodes.p_soundtrack: 'possible_soundtrack',
-                  FlagCodes.p_score: 'possible_score',
-                  FlagCodes.d_sq_brackets: 'detected_square_brackets',
-                  FlagCodes.d_parenthesis: 'detected_parenthesis',
-                  FlagCodes.l_group: 'likely_group_artist',
-                  FlagCodes.p_feat_artist: 'possible_featured_artist',
-                  FlagCodes.p_live: 'possible_live_performance',
-                  FlagCodes.p_demo: 'possible_demo_performance',
-                  FlagCodes.p_blank_track: 'possible_blank_track',
-                  FlagCodes.p_bonus_track: 'possible_bonus_track',
-                  FlagCodes.p_genre_country_folk:
-                  'country_and_folk_genre_is_too_vague',
-                  FlagCodes.m_year: 'missing_copyright_year',
-                  FlagCodes.m_title: 'missing_title',
-                  FlagCodes.m_album_title: 'missing_album_title',
-                  FlagCodes.m_track_artist: 'missing_artist'}
-        if in_code in matrix:
-            return matrix[in_code]
+        self.flags.append(in_code)
+
+    def to_xml_comment(self, in_padding: int = 3) -> str:
+        '''
+        Convert each flag code to an XML comment string value.
+        '''
+        p_str = ''
+        if in_padding > 0:
+            p_str = f"{' ' * in_padding}"
+        if len(self.flags) > 0:
+            flag_string = ''
+            for f_code in self.flags:
+                flag_string += TrackFlagCodes.to_str(f_code) + ' '
+            return f"{p_str}<!-- EDIT FLAGS: {flag_string} -->\n"
         return ''

--- a/src/musicscan/data/track.py
+++ b/src/musicscan/data/track.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 from tinytag import TinyTag  # type: ignore
-from musicscan.data.flags import Flags, FlagCodes
+from musicscan.data.flags import TrackFlags, TrackFlagCodes
 from musicscan.data.stringtools import sanitize_year
 
 
@@ -59,7 +59,7 @@ class Track():
         self.album_artist = ''
         self.composer = ''
         self.year = '0000'
-        self.flags = Flags()
+        self.flags = TrackFlags()
         # self.indices = []
         self._process(in_tag)
 
@@ -80,7 +80,7 @@ class Track():
         if in_tag.year:
             self.year = sanitize_year(in_tag.year)
         else:
-            self.flags.add_flag(FlagCodes.m_year)
+            self.flags.add_flag(TrackFlagCodes.m_year)
 
     def _process_integer_values(self, in_tag: TinyTag):
         '''

--- a/src/musicscan/xml/builder.py
+++ b/src/musicscan/xml/builder.py
@@ -66,10 +66,10 @@ class AbstractCompactDiscXML():
 
     def build_title(self, in_title: str) -> str:
         '''
-        XML Title Block
+        XML Album Title Block
         '''
         output = "  <title>\n"
-        output += f"   <main>{in_title}</main>\n"
+        output += f"   <main>{sanitize_for_xml(in_title)}</main>\n"
         output += "  </title>\n"
         return output
 
@@ -255,7 +255,7 @@ class AlbumElementXML():
         timestamp = datetime.datetime.now()
         output = "<album xmlns='http://vectortron.com/xml/media/audio'>\n"
         output += f" <!-- created by id3scan ({timestamp}) -->\n"
-        output += f" <title>{in_album.title}</title>\n"
+        output += f" <title>{sanitize_for_xml(in_album.title)}</title>\n"
         output += in_album.flags.to_xml_comment()
         output += self.build_chunk_catalog(in_album)
         output += self.build_chunk_classification(in_album)


### PR DESCRIPTION
Release ticket #57 

 - [musicscan-57](https://github.com/cjcodeproj/musicscan/issues/57) Release 0.1.7
 - [musicscan-36](https://github.com/cjcodeproj/musicscan/issues/36) Update some editing notes
 - [musicscan-52](https://github.com/cjcodeproj/musicscan/issues/52) Add new flags to RST documentation
 - [musicscan-40](https://github.com/cjcodeproj/musicscan/issues/40) Documentation: flags option flag
 - [musicscan-53](https://github.com/cjcodeproj/musicscan/issues/53) Album title is not sanitized
 - [musicscan-51](https://github.com/cjcodeproj/musicscan/issues/51) Edit flag for Intro and Reprise
 - [musicscan-22](https://github.com/cjcodeproj/musicscan/issues/22) Flag codes should probably be distinct between album and song
 - [musicscan-49](https://github.com/cjcodeproj/musicscan/issues/49) id3scan should be a bin tool
